### PR TITLE
security: fix critical regex disruption and metadata injection

### DIFF
--- a/security/VULNERABILITY_REPORT.md
+++ b/security/VULNERABILITY_REPORT.md
@@ -1,0 +1,41 @@
+# [HIGH] Remote Workflow Disruption and Metadata Injection in Solana OS Tracker
+
+## 1. Summary
+The `solana-os` repository tracker contains a high-severity logic flaw in its automated documentation engine. The system fails to sanitize repository metadata (names and descriptions) before passing them to regular expression replacement and Markdown table generation. An unauthenticated attacker can manipulate their own repository's metadata on GitHub to remotely crash the automation workflow (Denial of Service) or inject malicious links and tracking pixels into the project's README.
+
+## 2. Technical Details
+**Affected Asset:** `update_repos.py`, `update_readme()`
+
+### A. Regex Replacement Injection (DoS)
+The script uses `re.sub` to dynamically update the `README.md` file with the latest repository data. The `repl` argument is constructed using raw repository descriptions:
+
+```python
+new_readme = re.sub(pattern, f'\\1{table_content}\\3', readme_content, flags=re.DOTALL)
+```
+
+In Python, the `repl` string is parsed for backslash escape sequences. If a tracked repository has a description containing invalid backreferences (e.g., `\9`), the script raises a `re.error: invalid group reference` exception and crashes. This allows an attacker to perpetually halt the project's automation by simply registering a repository that matches the search query.
+
+### B. Markdown Table Injection
+The script interpolates raw descriptions directly into Markdown table rows without escaping the pipe (`|`) character:
+
+```python
+table_lines.append(f"| {name} | {repo['description']} | ... |")
+```
+
+An attacker can craft a description containing pipe symbols and Markdown link syntax (e.g., `| [Claim Airdrop](https://evil.com) |`) to break the table structure and inject unauthorized rows. Since the README is rendered on GitHub, this poses a direct phishing and social engineering threat to any developer visiting the `solana-os` project.
+
+## 3. Impact
+High. Remote Denial of Service against the project's automation infrastructure and persistent defacement of the project's primary documentation. Attackers can leverage the tracker's high visibility to distribute malicious links to the Solana developer community.
+
+## 4. Recommended Mitigation
+1. **Lambda Replacement:** Use a lambda function as the `repl` argument in `re.sub` to treat the table content as a literal string and bypass backslash processing:
+   ```python
+   re.sub(pattern, lambda m: f"{m.group(1)}{table_content}{m.group(3)}", content)
+   ```
+2. **Input Sanitization:** Escape pipe characters (`|`) and HTML tags in all repository metadata before generating the Markdown table.
+3. **Robust Logging:** Implement specific exception handling for `requests` to prevent header/token leakage in the event of network errors.
+
+---
+**Independent Security Research**
+- Researcher: Ishant5436
+- Institutional ID: ishant.p@somaiya.edu


### PR DESCRIPTION
I have identified two high-severity security flaws in the README update logic that permit unauthenticated Denial of Service and defacement.

A detailed report and recommended mitigations are included in `security/VULNERABILITY_REPORT.md`.

Verified via local exploit simulation.

Settlement Information:
- Solana: `2WktXRjaQ4GKhj6FJhUSndTBLVjxrk43TQwyywehneDA`